### PR TITLE
Deprecate ``--separator`` as a global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `list-depend` command shows the direct dependencies. It is handy to
 pre-install a database before running tests.
 
 ```console
-$ manifestoo -d /tmp/myaddons --separator=, list-depends
+$ manifestoo -d /tmp/myaddons list-depends --separator=,
 crm,mail
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,6 @@ $ manifestoo [OPTIONS] COMMAND [ARGS]...
 * `--addons-path-from-import-odoo / --no-addons-path-from-import-odoo`: Expand addons path by trying to `import odoo` and looking at `odoo.addons.__path__`. This option is useful when addons have been installed with pip.  [default: True]
 * `--addons-path-python PYTHON`: The python executable to use when importing `odoo.addons.__path__`. Defaults to the `python` executable found in PATH.
 * `--addons-path-from-odoo-cfg FILE`: Expand addons path by looking into the provided Odoo configuration file.   [env var: ODOO_RC]
-* `--separator TEXT`: Separator charater to use (by default, print one item per line).
 * `--odoo-series [8.0|9.0|10.0|11.0|12.0|13.0|14.0]`: Odoo series to use, in case it is not autodetected from addons version.  [env var: ODOO_VERSION, ODOO_SERIES]
 * `-v, --verbose`
 * `-q, --quiet`
@@ -65,7 +64,8 @@ $ manifestoo check-dev-status [OPTIONS]
 
 Check license compatibility.
 
-Check that selected addons only depend on addons with compatible licenses.
+Check that selected addons only depend on addons with compatible
+licenses.
 
 **Usage**:
 
@@ -90,6 +90,7 @@ $ manifestoo list [OPTIONS]
 
 **Options**:
 
+* `--separator TEXT`: Separator charater to use (by default, print one item per line).
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-depends`
@@ -104,6 +105,7 @@ $ manifestoo list-depends [OPTIONS]
 
 **Options**:
 
+* `--separator TEXT`: Separator charater to use (by default, print one item per line).
 * `--transitive`: Print all transitive dependencies.
 * `--include-selected`: Print the selected addons along with their dependencies.
 * `--ignore-missing`: Do not fail if dependencies are not found in addons path. This only applies to top level (selected) addons and transitive dependencies.
@@ -126,6 +128,7 @@ $ manifestoo list-external-dependencies [OPTIONS] KIND
 
 **Options**:
 
+* `--separator TEXT`: Separator charater to use (by default, print one item per line).
 * `--transitive`: Print external dependencies of all transitive dependent addons.
 * `--ignore-missing`: Do not fail if dependencies are not found in addons path. This only applies to top level (selected) addons and transitive dependencies.
 * `--help`: Show this message and exit.

--- a/news/1.removal
+++ b/news/1.removal
@@ -1,0 +1,2 @@
+Deprecate ``--separator`` as a global option. It belongs to commands that print
+lists.

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -101,9 +101,8 @@ def callback(
         ),
     ),
     separator: str = typer.Option(
-        default="\n",
-        show_default=False,
-        help="Separator charater to use (by default, print one item per line).",
+        default=None,
+        hidden=True,  # deprecated
     ),
     odoo_series: Optional[OdooSeries] = typer.Option(
         None,
@@ -142,7 +141,12 @@ def callback(
     echo.verbosity += verbose
     echo.verbosity -= quiet
     main_options = MainOptions()
-    main_options.separator = separator
+    if separator:
+        echo.warning(
+            "--separator is deprecated as a global option. "
+            "Please use the same option of list, list-depends."
+        )
+        main_options.separator = separator
     # resolve addons_path
     if select_addons_dirs:
         main_options.addons_path.extend_from_addons_dirs(select_addons_dirs)
@@ -182,16 +186,26 @@ def callback(
 
 
 @app.command()
-def list(ctx: typer.Context) -> None:
+def list(
+    ctx: typer.Context,
+    separator: Optional[str] = typer.Option(
+        None,
+        help="Separator charater to use (by default, print one item per line).",
+    ),
+) -> None:
     """Print the selected addons."""
     main_options: MainOptions = ctx.obj
     result = list_command(main_options.addons_selection)
-    print_list(result, ctx.obj.separator)
+    print_list(result, separator or main_options.separator or "\n")
 
 
 @app.command()
 def list_depends(
     ctx: typer.Context,
+    separator: Optional[str] = typer.Option(
+        None,
+        help="Separator charater to use (by default, print one item per line).",
+    ),
     transitive: bool = typer.Option(
         False,
         "--transitive",
@@ -235,7 +249,7 @@ def list_depends(
         raise typer.Abort()
     print_list(
         result,
-        ctx.obj.separator,
+        separator or main_options.separator or "\n",
     )
 
 
@@ -245,6 +259,10 @@ def list_external_dependencies(
     kind: str = typer.Argument(
         ...,
         help="Kind of external dependency, such as `python` or `deb`.",
+    ),
+    separator: Optional[str] = typer.Option(
+        None,
+        help="Separator charater to use (by default, print one item per line).",
     ),
     transitive: bool = typer.Option(
         False,
@@ -276,7 +294,7 @@ def list_external_dependencies(
         raise typer.Abort()
     print_list(
         result,
-        ctx.obj.separator,
+        separator or main_options.separator or "\n",
     )
 
 

--- a/src/manifestoo/options.py
+++ b/src/manifestoo/options.py
@@ -11,5 +11,5 @@ class MainOptions:
         self.addons_path = AddonsPath()
         self.addons_set = AddonsSet()
         self.addons_selection = AddonsSelection()
-        self.separator = "\n"
+        self.separator: Optional[str] = None  # deprecated
         self.odoo_series: Optional[OdooSeries] = None


### PR DESCRIPTION
closes #1 