### PR TITLE
[FIX] status levels: 'Stable/Production' label was not present

### DIFF
--- a/src/manifestoo/commands/check_dev_status.py
+++ b/src/manifestoo/commands/check_dev_status.py
@@ -13,6 +13,7 @@ DEV_STATUS_LEVELS = {
     "alpha": 1,
     "beta": 2,
     "production/stable": 3,
+    "stable/production": 3,
     "production": 3,
     "stable": 3,
     "mature": 4,


### PR DESCRIPTION
There is a lot of modules that have been defined this way:

https://github.com/OCA/storage/blob/12.0/storage_backend/__manifest__.py#L13

This usually happen with old modules, we have two options. Apply the change here or go, module by module and change the descriptor.