### PR TITLE
[IMP] Add list-missing command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Manifestoo is a command line tool that provides the following features:
 * listing direct and transitive dependencies of selected addons,
 * listing core Odoo CE and EE addons,
 * listing external dependencies,
+* listing missing dependencies,
 * displaying the dependency tree,
 * checking license compatibility,
 * checking development status compatibility.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -39,6 +39,7 @@ $ manifestoo [OPTIONS] COMMAND [ARGS]...
 * `list`: Print the selected addons.
 * `list-depends`: Print the dependencies of selected addons.
 * `list-external-dependencies`: Print the external dependencies of selected...
+* `list-missing`: Print the missing dependencies of selected addons.
 * `tree`: Print the dependency tree of selected addons.
 
 ## `manifestoo check-dev-status`
@@ -132,6 +133,16 @@ $ manifestoo list-external-dependencies [OPTIONS] KIND
 * `--transitive`: Print external dependencies of all transitive dependent addons.
 * `--ignore-missing`: Do not fail if dependencies are not found in addons path. This only applies to top level (selected) addons and transitive dependencies.
 * `--help`: Show this message and exit.
+
+**Usage**:
+
+```console
+$ manifestoo list-missing [OPTIONS]
+```
+
+**Options**:
+
+* `--separator TEXT`: Separator charater to use (by default, print one item per line).
 
 ## `manifestoo tree`
 

--- a/news/22.feature
+++ b/news/22.feature
@@ -1,0 +1,1 @@
+Add list-missing command

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -299,6 +299,28 @@ def list_external_dependencies(
 
 
 @app.command()
+def list_missing(
+    ctx: typer.Context,
+    separator: Optional[str] = typer.Option(
+        None,
+        help="Separator character to use (by default, print one item per line).",
+    ),
+) -> None:
+    """Print the missing dependencies of selected addons."""
+    main_options: MainOptions = ctx.obj
+    result, missing = list_depends_command(
+        main_options.addons_selection,
+        main_options.addons_set,
+        transitive=True,
+        include_selected=True,
+    )
+    print_list(
+        sorted(missing),
+        separator or main_options.separator or "\n",
+    )
+
+
+@app.command()
 def check_licenses(
     ctx: typer.Context,
     transitive: bool = typer.Option(

--- a/tests/test_list_missing.py
+++ b/tests/test_list_missing.py
@@ -1,0 +1,23 @@
+from typer.testing import CliRunner
+
+from manifestoo.main import app
+
+from .common import populate_addons_dir
+
+
+def test_list_missing(tmp_path):
+    addons = {
+        "a": {"depends": ["c"]},
+        "b": {"depends": ["d"]},
+        "e": {"depends": ["a", "b"]},
+    }
+    populate_addons_dir(tmp_path, addons)
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        [f"--select-addons-dir={tmp_path}", "list-missing"],
+        catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == "c\nd\n"


### PR DESCRIPTION
List missing modules in a new command

Because `manifestoo tree | grep not installed | sed ....` is not handy