### PR TITLE
Check if addon has an __init__.py

### DIFF
--- a/src/manifestoo/addon.py
+++ b/src/manifestoo/addon.py
@@ -11,6 +11,10 @@ class AddonNotFoundNotInstallable(AddonNotFound):
     pass
 
 
+class AddonNotFoundNoInit(AddonNotFound):
+    pass
+
+
 class AddonNotFoundNoManifest(AddonNotFound):
     pass
 
@@ -51,4 +55,6 @@ class Addon:
                 raise AddonNotFoundNotInstallable(f"{addon_dir} is not installable")
         except InvalidManifest as e:
             raise AddonNotFoundInvalidManifest(str(e)) from e
+        if not addon_dir.joinpath("__init__.py").is_file():
+            raise AddonNotFoundNoInit(f"{addon_dir} is missing an __init__.py")
         return cls(manifest)

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,7 @@ def populate_addons_dir(addons_dir: Path, addons: Dict[str, Dict[str, Any]]):
     for addon_name, manifest in addons.items():
         addon_path = addons_dir / addon_name
         addon_path.mkdir()
+        (addon_path / "__init__.py").touch()
         manifest_path = addon_path / "__manifest__.py"
         manifest_path.write_text(repr(manifest))
 

--- a/tests/test_addon.py
+++ b/tests/test_addon.py
@@ -1,18 +1,44 @@
+from pathlib import Path
+
 import pytest
 
 from manifestoo.addon import (
     Addon,
     AddonNotFoundInvalidManifest,
+    AddonNotFoundNoInit,
     AddonNotFoundNoManifest,
     AddonNotFoundNotADirectory,
     AddonNotFoundNotInstallable,
 )
 
 
-def test_basic(tmp_path):
-    addon_dir = tmp_path / "theaddon"
+@pytest.fixture(
+    params=[
+        {
+            "dir": "a",
+            "manifest": "{}",
+        }
+    ]
+)
+def addon_dir(request, tmp_path) -> Path:
+    addon_dir = tmp_path / request.param["dir"]
     addon_dir.mkdir()
-    (addon_dir / "__manifest__.py").write_text("{'name': 'the addon'}")
+    (addon_dir / "__init__.py").touch()
+    (addon_dir / "__manifest__.py").write_text(request.param["manifest"])
+    return addon_dir
+
+
+@pytest.mark.parametrize(
+    "addon_dir",
+    [
+        {
+            "dir": "theaddon",
+            "manifest": "{'name': 'the addon'}",
+        }
+    ],
+    indirect=True,
+)
+def test_basic(addon_dir):
     addon = Addon.from_addon_dir(addon_dir)
     assert addon.name == "theaddon"
     assert addon.path == addon_dir
@@ -24,31 +50,74 @@ def test_not_a_directory(tmp_path):
         Addon.from_addon_dir(tmp_path / "not-a-dir")
 
 
-def test_not_installable(tmp_path):
-    (tmp_path / "__manifest__.py").write_text("{'installable': False}")
+@pytest.mark.parametrize(
+    "addon_dir",
+    [
+        {
+            "dir": "a",
+            "manifest": "{'installable': False}",
+        }
+    ],
+    indirect=True,
+)
+def test_not_installable(addon_dir):
     with pytest.raises(AddonNotFoundNotInstallable):
-        Addon.from_addon_dir(tmp_path)
-    assert Addon.from_addon_dir(tmp_path, allow_not_installable=True)
+        Addon.from_addon_dir(addon_dir)
+    assert Addon.from_addon_dir(addon_dir, allow_not_installable=True)
 
 
-def test_invalid_manifest(tmp_path):
-    (tmp_path / "__manifest__.py").write_text("[]")
+@pytest.mark.parametrize(
+    "addon_dir",
+    [
+        {
+            "dir": "a",
+            "manifest": "[]",
+        }
+    ],
+    indirect=True,
+)
+def test_invalid_manifest(addon_dir):
     with pytest.raises(AddonNotFoundInvalidManifest):
-        Addon.from_addon_dir(tmp_path)
+        Addon.from_addon_dir(addon_dir)
 
 
-def test_manifest_syntax_error(tmp_path):
-    (tmp_path / "__manifest__.py").write_text("{'installable':}")
+@pytest.mark.parametrize(
+    "addon_dir",
+    [
+        {
+            "dir": "a",
+            "manifest": "{'installable':}",
+        }
+    ],
+    indirect=True,
+)
+def test_manifest_syntax_error(addon_dir):
     with pytest.raises(AddonNotFoundInvalidManifest):
-        Addon.from_addon_dir(tmp_path)
+        Addon.from_addon_dir(addon_dir)
 
 
-def test_manifest_type_error(tmp_path):
-    (tmp_path / "__manifest__.py").write_text("{'installable': '?'}")
+@pytest.mark.parametrize(
+    "addon_dir",
+    [
+        {
+            "dir": "a",
+            "manifest": "{'installable': '?'}",
+        }
+    ],
+    indirect=True,
+)
+def test_manifest_type_error(addon_dir):
     with pytest.raises(AddonNotFoundInvalidManifest):
-        Addon.from_addon_dir(tmp_path)
+        Addon.from_addon_dir(addon_dir)
 
 
-def test_no_manifest(tmp_path):
+def test_no_manifest(addon_dir):
+    (addon_dir / "__manifest__.py").unlink()
     with pytest.raises(AddonNotFoundNoManifest):
-        Addon.from_addon_dir(tmp_path)
+        Addon.from_addon_dir(addon_dir)
+
+
+def test_no_init(addon_dir):
+    (addon_dir / "__init__.py").unlink()
+    with pytest.raises(AddonNotFoundNoInit):
+        Addon.from_addon_dir(addon_dir)


### PR DESCRIPTION
This is a possible fix for #5 

Because creating a test module is not as trivial as it was before (it needs a valid manifest and an init file), I created a fixture to  create modules for the test of Addon.

A step further would be to also refactor test/common.py:populate_addons_dir to be a fixture too.