### PR TITLE
Fix list-codepends boolean flags

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -111,8 +111,8 @@ $ manifestoo list-codepends [OPTIONS]
 **Options**:
 
 * `--separator TEXT`: Separator character to use (by default, print one item per line).
-* `--transitive`: Print all transitive co-dependencies.  [default: True]
-* `--include-selected`: Print the selected addons along with their co-dependencies.  [default: True]
+* `--transitive / --no-transitive`: Print all transitive co-dependencies.  [default: True]
+* `--include-selected / --no-include-selected`: Print the selected addons along with their co-dependencies.  [default: True]
 * `--help`: Show this message and exit.
 
 ## `manifestoo list-depends`

--- a/news/28.bugfix
+++ b/news/28.bugfix
@@ -1,0 +1,2 @@
+Add ``--no-transitive`` and ``--no-include-selected`` options to the ``list-codepends``
+so the default values can be switched off.

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -263,12 +263,10 @@ def list_codepends(
     ),
     transitive: bool = typer.Option(
         True,
-        "--transitive",
         help="Print all transitive co-dependencies.",
     ),
     include_selected: bool = typer.Option(
         True,
-        "--include-selected",
         help="Print the selected addons along with their co-dependencies.",
     ),
 ) -> None:


### PR DESCRIPTION
Since the transitive and include_select flags of list-codepends
are enabled by default, we need a way to disable them.