### PR TITLE
feat: add `--select-found` flag

### DIFF
--- a/docs/addons_selection.md
+++ b/docs/addons_selection.md
@@ -49,6 +49,11 @@ manifestoo --select-core-addons --odoo-series=13.0 list
 The list of core Odoo addons is static and part of the manifestoo release.
 ```
 
+## Selectiong found addons
+
+You can use `--select-found` to include all addons that are found in the current
+Odoo installation.
+
 ## Excluding addons
 
 With `--select-exclude`, you can provide a comma separated list of addons to

--- a/news/17.feature
+++ b/news/17.feature
@@ -1,0 +1,1 @@
+Add ``--select-found`` flag to select all addons available to the detected Odoo isntallation.

--- a/src/manifestoo/main.py
+++ b/src/manifestoo/main.py
@@ -33,6 +33,11 @@ def version_callback(value: bool) -> None:
 @app.callback()
 def callback(
     ctx: typer.Context,
+    select_found: bool = typer.Option(
+        False,
+        "--select-found",
+        help="Select all installable addons found in addons path(s).",
+    ),
     select_addons_dirs: Optional[List[Path]] = typer.Option(
         None,
         "--select-addons-dir",
@@ -182,6 +187,8 @@ def callback(
         else:
             main_options.odoo_series = detected_odoo_series.pop()
     # addons selection
+    if select_found:
+        main_options.addons_selection.add_addons_dirs(main_options.addons_path)
     if select_addons_dirs:
         main_options.addons_selection.add_addons_dirs(select_addons_dirs)
     if select_include:

--- a/tests/test_cmd_list.py
+++ b/tests/test_cmd_list.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 from typer.testing import CliRunner
 
 from manifestoo.commands.list import list_command
@@ -22,6 +24,30 @@ def test_integration(tmp_path):
         app,
         [f"--select-addons-dir={tmp_path}", "list"],
         catch_exceptions=False,
+    )
+    assert not result.exception
+    assert result.exit_code == 0, result.stderr
+    assert result.stdout == "a\nb\n"
+
+
+def test_found(tmp_path):
+    addons = {"a": {}, "b": {}, "c": {"installable": False}}
+    populate_addons_dir(tmp_path, addons)
+    conf = tmp_path / "odoo.conf"
+    conf.write_text(
+        dedent(
+            f"""\
+            [options]
+            addons_path = {tmp_path}
+            """
+        )
+    )
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        app,
+        ["--select-found", "list"],
+        catch_exceptions=False,
+        env={"ODOO_RC": str(conf)},
     )
     assert not result.exception
     assert result.exit_code == 0, result.stderr


### PR DESCRIPTION
Easy way to get all available addons to the current environment (or path selection).

Closes https://github.com/sbidoul/manifestoo/issues/17.